### PR TITLE
Removed jQuery code, small background fix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,7 @@
 }
 
 html {
+	height: 100%;
 	background: url("/img/bg.jpg") no-repeat center center fixed;
 	-webkit-background-size: cover;
 	-moz-background-size: cover;

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
 		<meta name="twitter:image" content="http://i.imgur.com/lI04stD.png" />
 		<link rel="stylesheet" type="text/css" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" />
 		<link rel="stylesheet" href="/css/style.css" type="text/css" />
-		<script type="text/javascript" src="/js/jquery.min.js"></script>
 	</head>
 	<body>
 		<div class="center">
@@ -42,9 +41,10 @@
 			</div>
 		</div>
 		<script type="text/javascript">
-			$(document).ready(function(){
-				$("a:not([href*='mailto:'])").attr("target", "_blank");
-			});
+			var elements = document.querySelectorAll("a:not([href*='mailto:']");
+			for (var i = 0; i < elements.length; i++) {
+				elements[i].setAttribute("target", "_blank");
+			}
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
Firstly: no jQuery is needed to perform the simple task of setting links to `target="_blank"`. I rewrote this in pure JavaScript using the IE8+ DOM API. While this may result in slightly more ugly code, the benefit is a speedup of page load; not having to load jQuery and not having to use it.

Secondly, there was a major bug in the way that `background-size: cover` worked on Chrome for Android. It would display the webpage like this:

[image](https://cloud.githubusercontent.com/assets/6015058/5584806/cc7342d8-90ec-11e4-95a2-2a2e02b7d89b.png)

A simple fix to this is setting `height: 100%` on the element the background was set.